### PR TITLE
Fix command line flag parsing for common options

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     # run only against tags
     tags:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,21 @@
+name: Go
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        uses: robherley/go-test-action@v0

--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -9,6 +9,7 @@ import (
 	// "golang.org/x/mod/semver"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -16,7 +17,8 @@ import (
 var bumpCmd = &cobra.Command{
 	Use:   "bump",
 	Short: "Bump a semver version",
-	Long: `Bump a semver version to the next major, minor, patch, or prerelease version.
+	Long: `
+	Bump a semver version to the next major, minor, patch, or prerelease version.
 
 	Examples:
 	semvertool bump --major 0.1.0-alpha.1+build.1
@@ -34,36 +36,44 @@ var bumpCmd = &cobra.Command{
 	semvertool bump --prerelease 1.1.1-alpha.1.0
 	1.1.1-alpha.1.1
 	
-	semvertool bump --build $(git rev-parse --short HEAD) 1.1.1-alpha.1
-	1.1.1-alpha.2+3f6d1270
-	
-	semvertool bump 1.1.1-alpha.2+3f6d1270`,
+	semvertool bump 1.1.1-alpha.2+3f6d1270
+	1.1.1
+
+	semvertool bump --prerelease --prerelease-prefix snapshot 1.1.1
+	1.1.2-snapshot.1
+	`,
 	Run: runBump,
 }
 
 func init() {
 	rootCmd.AddCommand(bumpCmd)
 
-	addCommonBumpFlags(bumpCmd)
-	bumpCmd.Flags().String("metadata", "", "Append the given string to the version as metadata.")
-
-	viper.BindPFlags(bumpCmd.Flags())
+	cf := getCommonBumpFlags()
+	bumpCmd.Flags().AddFlagSet(cf)
+	bumpCmd.Flags().StringP("metadata", "", "", "Append the given string to the version as metadata.")
+	bumpCmd.MarkFlagsMutuallyExclusive("major", "minor", "patch", "prerelease", "from-message")
 }
 
 func runBump(cmd *cobra.Command, args []string) {
-
+	// Flags can only be bound once, so it needs to be done in the Run function
+	// The also need to be done one at a time, so we can't use BindPFlags
+	// See https://github.com/spf13/viper/issues/375#issuecomment-794668149
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		_ = viper.BindPFlag(flag.Name, flag)
+	})
 	if len(args) < 1 {
-		cmd.Help()
+		_ = cmd.Help()
 		return
 	}
 	if len(args) > 1 {
 		fmt.Println("Too many arguments")
 		fmt.Println()
-		cmd.Help()
+		_ = cmd.Help()
 		return
 	}
 	oldV := args[0]
-	newV, err := doBump(oldV, getBumpType())
+	bumpType := getBumpType()
+	newV, err := doBump(oldV, bumpType)
 	if err != nil {
 		fmt.Println("Error bumping version:", err)
 		return

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	goget "github.com/go-git/go-git/v5"
@@ -44,6 +45,14 @@ var gitCmd = &cobra.Command{
 	git tag v1.0.0-alpha.2+3f6d1270
 	semvertool git --minor
 	v1.1.0
+
+	git tag v1.0.0-alpha.3+3f6d1270
+	semvertool git
+	v1.0.1
+
+	git tag v1.1.0
+	semvertool git --prerelease
+	v1.1.1-alpha.1
 	`,
 	Run: runGit,
 }
@@ -51,10 +60,12 @@ var gitCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(gitCmd)
 
-	addCommonBumpFlags(gitCmd)
+	cf := getCommonBumpFlags()
+	gitCmd.Flags().AddFlagSet(cf)
 	gitCmd.Flags().BoolP("hash", "s", false, "Append the short hash (sha) to the version as metadata information.")
 	gitCmd.Flags().BoolP("from-commit", "c", false, "Extract the bump type from a commit message")
-	viper.BindPFlags(gitCmd.Flags())
+	gitCmd.MarkFlagsMutuallyExclusive("major", "minor", "patch", "prerelease", "from-message", "from-commit")
+
 }
 
 func getTags(repo *goget.Repository) ([]*semver.Version, error) {
@@ -130,8 +141,14 @@ func gitBump(repo *goget.Repository) (*semver.Version, error) {
 }
 
 func runGit(cmd *cobra.Command, args []string) {
+	// Flags can only be bound once, so it needs to be done in the Run function
+	// The also need to be done one at a time, so we can't use BindPFlags
+	// See https://github.com/spf13/viper/issues/375#issuecomment-794668149
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		_ = viper.BindPFlag(flag.Name, flag)
+	})
 	if len(args) != 0 {
-		fmt.Println("No arguments allowed")
+		fmt.Printf("Unexpected arguments: %v\n", args)
 		return
 	}
 

--- a/cmd/git_test.go
+++ b/cmd/git_test.go
@@ -29,6 +29,15 @@ import (
 func setupRepo() (*git.Repository, error) {
 	fs := memfs.New()
 	repo, err := git.Init(memory.NewStorage(), fs)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil, err
+	}
+	cfg.Author.Name = "Test Author"
+	cfg.Author.Email = "test_email@example.com"
 
 	return repo, err
 }

--- a/cmd/git_test.go
+++ b/cmd/git_test.go
@@ -183,7 +183,26 @@ func TestGitBump_WithHash(t *testing.T) {
 
 	viper.Set("hash", true)
 	result, err := gitBump(repo)
+	viper.Reset()
 	expected := "v1.0.1+" + shortHash
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result.Original())
+}
+
+func TestGitBump_WithPrereleasePrefix(t *testing.T) {
+	repo, err := setupRepo()
+	assert.NoError(t, err)
+
+	commit, err := commitFile("file1.txt", repo)
+	assert.NoError(t, err)
+
+	_, err = repo.CreateTag("v1.0.0", commit, nil)
+	assert.NoError(t, err)
+
+	viper.Set("prerelease", true)
+	viper.Set("prerelease-prefix", "alpha")
+	result, err := gitBump(repo)
+	expected := "v1.0.1-alpha.1"
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result.Original())
 }

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.21
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
 )
@@ -20,7 +22,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -38,7 +39,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.uber.org/atomic v1.9.0 // indirect


### PR DESCRIPTION
* Add flag to set the prefix for a prerelease if one isn't present on the given version.
* Add tests for the new flag
* Update tests to catch a few more edge cases

Fixes #2