### PR TITLE
Add compare command to semvertool

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "test": "go test ./... -cover"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -78,3 +78,19 @@ git tag v1.0.0-alpha.2+3f6d1270
 semvertool git --minor
 v1.1.0
 ```
+
+### compare
+
+Compare two semver versions and return an exit code based on their comparison.
+
+```shell
+Examples:
+semvertool compare 1.0.0 2.0.0
+2
+
+semvertool compare 2.0.0 2.0.0
+1
+
+semvertool compare 2.0.0 1.0.0
+0
+```

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -1,0 +1,71 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Masterminds/semver"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// compareCmd represents the compare command
+var compareCmd = &cobra.Command{
+	Use:   "compare",
+	Short: "Compare two semver versions",
+	Long: `
+	Compare two semver versions and return an exit code based on their comparison.
+
+	Examples:
+	semvertool compare 1.0.0 2.0.0
+	2
+
+	semvertool compare 2.0.0 2.0.0
+	1
+
+	semvertool compare 2.0.0 1.0.0
+	0
+	`,
+	Run: runCompare,
+}
+
+func init() {
+	rootCmd.AddCommand(compareCmd)
+}
+
+func runCompare(cmd *cobra.Command, args []string) {
+	// Flags can only be bound once, so it needs to be done in the Run function
+	// They also need to be done one at a time, so we can't use BindPFlags
+	// See https://github.com/spf13/viper/issues/375#issuecomment-794668149
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		_ = viper.BindPFlag(flag.Name, flag)
+	})
+	if len(args) != 2 {
+		fmt.Println("Two arguments are required")
+		_ = cmd.Help()
+		os.Exit(1)
+	}
+	v1, err := semver.NewVersion(args[0])
+	if err != nil {
+		fmt.Println("Invalid first version:", err)
+		os.Exit(1)
+	}
+	v2, err := semver.NewVersion(args[1])
+	if err != nil {
+		fmt.Println("Invalid second version:", err)
+		os.Exit(1)
+	}
+	result := v1.Compare(v2)
+	switch {
+	case result < 0:
+		os.Exit(0)
+	case result == 0:
+		os.Exit(1)
+	case result > 0:
+		os.Exit(2)
+	}
+}

--- a/cmd/compare_test.go
+++ b/cmd/compare_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name     string
+		version1 string
+		version2 string
+		expected int
+	}{
+		{"FirstSmaller", "1.0.0", "2.0.0", 0},
+		{"Equal", "2.0.0", "2.0.0", 1},
+		{"SecondSmaller", "2.0.0", "1.0.0", 2},
+		{"PreReleaseFirstSmaller", "1.0.0-alpha", "1.0.0-beta", 0},
+		{"PreReleaseEqual", "1.0.0-alpha", "1.0.0-alpha", 1},
+		{"PreReleaseSecondSmaller", "1.0.0-beta", "1.0.0-alpha", 2},
+		{"PreReleaseAlpha1Smaller", "1.0.0-alpha.1", "1.0.0-alpha.8", 0},
+		{"PreReleaseAlphaEqual", "1.0.0-alpha.1", "1.0.0-alpha.1", 1},
+		{"PreReleaseAlpha8Smaller", "1.0.0-alpha.8", "1.0.0-alpha.1", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("go", "run", "../main.go", "compare", tt.version1, tt.version2)
+			err := cmd.Run()
+			exitError, ok := err.(*exec.ExitError)
+			if err == nil {
+				assert.Equal(t, tt.expected, 1)
+			} else if !ok {
+				t.Fatalf("expected exit error, got %v", err)
+			} else {
+				assert.Equal(t, tt.expected, exitError.ExitCode())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a new `compare` command to the main program to compare two semver versions and return an exit code based on their comparison.

* **cmd/compare.go**: Add a new command `compare` to compare two semvers using `semver.Compare` and return exit codes 0, 1, or 2 based on the comparison result.
* **cmd/compare_test.go**: Add tests for the `compare` command, including cases for comparing versions with pre-release information.
* **README.md**: Update to include usage instructions for the new `compare` command.
* **.devcontainer.json**: Add a configuration file with a test task to run all tests with coverage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaevans/semvertool?shareId=e3c1d10b-04fa-40fc-8914-472f026def7b).