### PR TITLE
Add sort command to semvertool

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,26 @@ git tag v1.0.0-alpha.2+3f6d1270
 semvertool git --minor
 v1.1.0
 ```
+
+### sort
+
+Sort a list of semver strings in ascending or descending order.
+
+```shell
+semvertool sort 1.0.0 2.0.0 0.1.0
+0.1.0 1.0.0 2.0.0
+
+semvertool sort --descending 1.0.0 2.0.0 0.1.0
+2.0.0 1.0.0 0.1.0
+
+semvertool sort --separator "," 1.0.0 2.0.0 0.1.0
+0.1.0,1.0.0,2.0.0
+
+semvertool sort --separator "\n" 1.0.0 2.0.0 0.1.0
+0.1.0
+1.0.0
+2.0.0
+
+semvertool sort 1.0.0-alpha.1 1.0.0 1.0.0-beta.1
+1.0.0-alpha.1 1.0.0-beta.1 1.0.0
+```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var sortCmd = &cobra.Command{
+	Use:   "sort",
+	Short: "Sort a list of semver strings",
+	Long: `Sort a list of semver strings in ascending or descending order.
+
+Examples:
+semvertool sort 1.0.0 2.0.0 0.1.0
+0.1.0 1.0.0 2.0.0
+
+semvertool sort --descending 1.0.0 2.0.0 0.1.0
+2.0.0 1.0.0 0.1.0
+
+semvertool sort --separator "," 1.0.0 2.0.0 0.1.0
+0.1.0,1.0.0,2.0.0
+`,
+	Run: runSort,
+}
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "semvertool",
@@ -38,4 +56,5 @@ func init() {
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
+	rootCmd.AddCommand(sortCmd)
 }

--- a/cmd/sort.go
+++ b/cmd/sort.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// sortCmd represents the sort command
+var sortCmd = &cobra.Command{
+	Use:   "sort",
+	Short: "Sort a list of semver strings",
+	Long: `Sort a list of semver strings in ascending or descending order.
+
+Examples:
+semvertool sort 1.0.0 2.0.0 0.1.0
+0.1.0 1.0.0 2.0.0
+
+semvertool sort --descending 1.0.0 2.0.0 0.1.0
+2.0.0 1.0.0 0.1.0
+
+semvertool sort --separator "," 1.0.0 2.0.0 0.1.0
+0.1.0,1.0.0,2.0.0
+`,
+	Run: runSort,
+}
+
+func init() {
+	rootCmd.AddCommand(sortCmd)
+
+	sortCmd.Flags().BoolP("descending", "d", false, "Sort in descending order")
+	sortCmd.Flags().StringP("separator", "s", " ", "Separator for the output")
+}
+
+func runSort(cmd *cobra.Command, args []string) {
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		_ = viper.BindPFlag(flag.Name, flag)
+	})
+
+	if len(args) < 1 {
+		_ = cmd.Help()
+		return
+	}
+
+	versions := make([]*semver.Version, len(args))
+	for i, arg := range args {
+		v, err := semver.NewVersion(arg)
+		if err != nil {
+			fmt.Printf("Invalid semver string: %s\n", arg)
+			return
+		}
+		versions[i] = v
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		if viper.GetBool("descending") {
+			return versions[i].LessThan(versions[j])
+		}
+		return versions[j].LessThan(versions[i])
+	})
+
+	sep := viper.GetString("separator")
+	versionStrings := make([]string, len(versions))
+	for i, v := range versions {
+		versionStrings[i] = v.String()
+	}
+
+	fmt.Println(strings.Join(versionStrings, sep))
+}

--- a/cmd/sort_test.go
+++ b/cmd/sort_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortAscending(t *testing.T) {
+	cmd := exec.Command("../semvertool", "sort", "1.0.0", "2.0.0", "0.1.0")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, "0.1.0 1.0.0 2.0.0\n", out.String())
+}
+
+func TestSortDescending(t *testing.T) {
+	cmd := exec.Command("../semvertool", "sort", "--desc", "1.0.0", "2.0.0", "0.1.0")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, "2.0.0 1.0.0 0.1.0\n", out.String())
+}
+
+func TestSortWithSeparator(t *testing.T) {
+	cmd := exec.Command("../semvertool", "sort", "--sep", ",", "1.0.0", "2.0.0", "0.1.0")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, "0.1.0,1.0.0,2.0.0\n", out.String())
+}
+
+func TestSortWithNewlineSeparator(t *testing.T) {
+	cmd := exec.Command("../semvertool", "sort", "--sep", "\n", "1.0.0", "2.0.0", "0.1.0")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, "0.1.0\n1.0.0\n2.0.0\n", out.String())
+}
+
+func TestSortInvalidSemver(t *testing.T) {
+	cmd := exec.Command("../semvertool", "sort", "1.0.0", "invalid", "0.1.0")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	assert.Error(t, err)
+	assert.Contains(t, out.String(), "Invalid semver string: invalid")
+}
+
+func TestSortWithPrereleaseVersions(t *testing.T) {
+	cmd := exec.Command("../semvertool", "sort", "1.0.0-alpha.1", "1.0.0-alpha.2", "1.0.0-beta.1")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, "1.0.0-alpha.1 1.0.0-alpha.2 1.0.0-beta.1\n", out.String())
+}
+
+func TestSortUnsortedInput(t *testing.T) {
+	cmd := exec.Command("../semvertool", "sort", "2.0.0", "0.1.0", "1.0.0")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, "0.1.0 1.0.0 2.0.0\n", out.String())
+}


### PR DESCRIPTION
Add a new `sort` command to sort a list of semver strings.

* **cmd/sort.go**
  - Add `sortCmd` using `cobra.Command`.
  - Implement `runSort` function to handle sorting logic.
  - Add flags `--descending` and `--separator`.
  - Validate semver strings and print error message if invalid.
  - Handle prerelease versions correctly in sorting logic.

* **cmd/root.go**
  - Import and add `sortCmd` to the root command.
  - Update help output to use `--descending` and `--separator`.

* **cmd/sort_test.go**
  - Add unit tests for the `sort` command.
  - Test sorting in ascending and descending order.
  - Test different separators for the output.
  - Test invalid semver strings.
  - Test sorting with prerelease versions.
  - Add a test where the test values are not already in sorted order.

* **README.md**
  - Add usage examples for the `sort` command.
  - Document the `--descending` and `--separator` flags.
  - Add an example of using a mixed set of prerelease and version tags in the help output.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaevans/semvertool/pull/5?shareId=072b7bae-6657-499b-9bbc-9667fde64ab2).